### PR TITLE
expose type to createWallet function

### DIFF
--- a/Sources/ParaSwift/Core/ParaManager.swift
+++ b/Sources/ParaSwift/Core/ParaManager.swift
@@ -221,8 +221,8 @@ extension ParaManager {
 @available(iOS 16.4,*)
 extension ParaManager {
     @MainActor
-    public func createWallet(skipDistributable: Bool) async throws {
-        _ = try await postMessage(method: "createWallet", arguments: ["EVM", skipDistributable])
+    public func createWallet(type: WalletType, skipDistributable: Bool) async throws {
+        _ = try await postMessage(method: "createWallet", arguments: [type.rawValue, skipDistributable])
         self.wallets = try await fetchWallets()
         self.sessionState = .activeLoggedIn
     }

--- a/Sources/ParaSwift/Models/Wallet.swift
+++ b/Sources/ParaSwift/Models/Wallet.swift
@@ -7,10 +7,14 @@
 
 import Foundation
 
+public enum WalletType: String {
+    case evm = "EVM", solana = "SOLANA", cosmos = "COSMOS"
+}
+
 public struct Wallet {
     public let id: String
     public let userId: String?
-    public let type: String?
+    public let type: WalletType?
     public let pregenIdentifier: String?
     public let pregenIdentifierType: String?
     public let keyGenComplete: Bool?
@@ -45,7 +49,9 @@ public struct Wallet {
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
         id = result["id"]! as! String
         userId = result["userId"] as? String
-        type = result["type"] as? String
+        
+        let typeString = result["type"] as? String
+        type = typeString.flatMap(WalletType.init)
         pregenIdentifier = result["pregenIdentifier"] as? String
         pregenIdentifierType = result["pregenIdentifierType"] as? String
         keyGenComplete = result["keyGenComplete"] as? Bool

--- a/example/example/EmailAuthView.swift
+++ b/example/example/EmailAuthView.swift
@@ -59,6 +59,7 @@ struct EmailAuthView: View {
                             shouldNavigateToVerifyEmail = true
                         }
                     } catch {
+                        print(error.localizedDescription)
                         errorMessage = "Failed to create user: \(error.localizedDescription)"
                         isLoading = false
                     }

--- a/example/example/VerifyEmailView.swift
+++ b/example/example/VerifyEmailView.swift
@@ -57,7 +57,7 @@ struct VerifyEmailView: View {
                         loadingStateText = "Generating Passkey..."
                         try await paraManager.generatePasskey(identifier: email, biometricsId: biometricsId, authorizationController: authorizationController)
                         loadingStateText = "Creating Wallet..."
-                        try await paraManager.createWallet(skipDistributable: false)
+                        try await paraManager.createWallet(type: .evm, skipDistributable: false)
                         isLoading = false
                         appRootManager.currentRoot = .home
                     } catch {

--- a/example/example/VerifyPhoneView.swift
+++ b/example/example/VerifyPhoneView.swift
@@ -58,7 +58,7 @@ struct VerifyPhoneView: View {
                         loadingStateText = "Generating Passkey..."
                         try await paraManager.generatePasskey(identifier: "\(countryCode)\(phoneNumber)", biometricsId: biometricsId, authorizationController: authorizationController)
                         loadingStateText = "Creating Wallet..."
-                        try await paraManager.createWallet(skipDistributable: false)
+                        try await paraManager.createWallet(type: .evm, skipDistributable: false)
                         isLoading = false
                         appRootManager.currentRoot = .home
                     } catch {

--- a/example/example/WalletView.swift
+++ b/example/example/WalletView.swift
@@ -236,7 +236,7 @@ struct WalletView: View {
                     errorMessage = nil
                     Task {
                         do {
-                            try await paraManager.createWallet(skipDistributable: false)
+                            try await paraManager.createWallet(type: .evm, skipDistributable: false)
                             creatingWallet = false
                         } catch {
                             creatingWallet = false


### PR DESCRIPTION
This pull request includes changes to the `ParaSwift` library and its example application to support different wallet types. The main changes involve the introduction of a new `WalletType` enum and updating the `createWallet` method to use this enum.

### Support for Wallet Types:

* [`Sources/ParaSwift/Core/ParaManager.swift`](diffhunk://#diff-2261f65aeb504ed399f74529b41ad2a9dd6ba116f8f0536e43ff9ab796a9dc6eL224-R225): Modified the `createWallet` method to accept a `WalletType` parameter instead of a string.
* [`Sources/ParaSwift/Models/Wallet.swift`](diffhunk://#diff-2fb9c72fa66a264ae4a3509ca0f1d7d9f5c7290c0f0525aa6805659839d0c838R10-R17): Introduced a new `WalletType` enum and updated the `Wallet` struct to use this enum for the `type` property. [[1]](diffhunk://#diff-2fb9c72fa66a264ae4a3509ca0f1d7d9f5c7290c0f0525aa6805659839d0c838R10-R17) [[2]](diffhunk://#diff-2fb9c72fa66a264ae4a3509ca0f1d7d9f5c7290c0f0525aa6805659839d0c838L48-R54)

### Example Application Updates:

* [`example/example/EmailAuthView.swift`](diffhunk://#diff-3d60c13a5d7dfffa10da13522ad6e4827c38e2a862b582eb8bdf928127dd7f6cR62): Added a print statement to log errors when user creation fails.
* [`example/example/VerifyEmailView.swift`](diffhunk://#diff-a2207365cc7497c2b7f0f8b96710cc85811f2a6be89669228adcaf6060d70e2fL60-R60): Updated the `createWallet` method call to use the new `WalletType` enum.
* [`example/example/VerifyPhoneView.swift`](diffhunk://#diff-f0db4b2562652d0969a184b11c0117ecdbf44c0bf6ce261099b2300f8f6769c5L61-R61): Updated the `createWallet` method call to use the new `WalletType` enum.
* [`example/example/WalletView.swift`](diffhunk://#diff-173bdebc27d42426bfe84fe5f319679c956af92cb0947d373b34479ded090609L239-R239): Updated the `createWallet` method call to use the new `WalletType` enum.