### PR TITLE
feat: add support for returning complete signed EVM transactions

### DIFF
--- a/Sources/ParaSwift/Core/ParaManager+Signing.swift
+++ b/Sources/ParaSwift/Core/ParaManager+Signing.swift
@@ -6,15 +6,26 @@ import Foundation
 public struct SignatureResult {
     /// The signature string
     public let signature: String
+    /// The complete signed transaction (for EVM, includes full RLP-encoded transaction ready for eth_sendRawTransaction)
+    public let signedTransaction: String?
     /// The wallet ID that signed
     public let walletId: String
     /// The wallet type (e.g., "evm", "solana", "cosmos")
     public let type: String
     
-    public init(signature: String, walletId: String, type: String) {
+    public init(signature: String, signedTransaction: String? = nil, walletId: String, type: String) {
         self.signature = signature
+        self.signedTransaction = signedTransaction
         self.walletId = walletId
         self.type = type
+    }
+    
+    /// Returns the transaction data for broadcasting.
+    /// For EVM chains, returns signedTransaction if available (complete RLP-encoded transaction),
+    /// otherwise falls back to signature for backward compatibility.
+    /// For other chains, returns the signature.
+    public var transactionData: String {
+        return signedTransaction ?? signature
     }
 }
 
@@ -98,11 +109,13 @@ public extension ParaManager {
         let dict = try decodeResult(result, expectedType: [String: Any].self, method: "formatAndSignMessage")
         
         let signature = dict["signature"] as? String ?? ""
+        let signedTransaction = dict["signedTransaction"] as? String
         let returnedWalletId = dict["walletId"] as? String ?? walletId
         let walletType = dict["type"] as? String ?? "unknown"
         
         return SignatureResult(
             signature: signature,
+            signedTransaction: signedTransaction,
             walletId: returnedWalletId,
             type: walletType
         )
@@ -155,11 +168,13 @@ public extension ParaManager {
         let dict = try decodeResult(result, expectedType: [String: Any].self, method: "formatAndSignTransaction")
         
         let signature = dict["signature"] as? String ?? ""
+        let signedTransaction = dict["signedTransaction"] as? String
         let returnedWalletId = dict["walletId"] as? String ?? walletId
         let walletType = dict["type"] as? String ?? "unknown"
         
         return SignatureResult(
             signature: signature,
+            signedTransaction: signedTransaction,
             walletId: returnedWalletId,
             type: walletType
         )


### PR DESCRIPTION
## Summary
- Adds the ability to return full RLP-encoded signed transactions for EVM chains, not just signatures
- Extends the SignatureResult to include complete signed transaction data for EVM chains

## Changes
- Added `signedTransaction` field to `SignatureResult` struct for EVM support
- Updated transaction signing flow to provide complete signed transaction when available
- Maintains backward compatibility while providing enhanced EVM transaction support

## Test Plan
- [ ] Test signing EVM transactions and verify complete signed transaction is returned
- [ ] Verify backward compatibility with existing signature flows
- [ ] Test with various EVM chains to ensure proper transaction formatting

🤖 Generated with [Claude Code](https://claude.ai/code)