### PR TITLE
fix: handleVerificationCode returns auth state for all stages

### DIFF
--- a/Sources/ParaSwift/Core/ParaManager+Auth.swift
+++ b/Sources/ParaSwift/Core/ParaManager+Auth.swift
@@ -250,6 +250,12 @@ public extension ParaManager {
         let authState = try await signUpOrLogIn(auth: auth)
         logger.debug("Auth flow initiated. Resulting stage: \(authState.stage.rawValue)")
 
+        if authState.stage == .done {
+            logger.debug("Auth flow returned .done stage (SLO/enclave user). Finalizing session.")
+            await finalizeHostedAuthFlow(initialStage: .done)
+            return authState
+        }
+
         guard let loginUrl = authState.loginUrl else {
             return authState
         }

--- a/Sources/ParaSwift/Core/ParaManager+Auth.swift
+++ b/Sources/ParaSwift/Core/ParaManager+Auth.swift
@@ -407,10 +407,6 @@ public extension ParaManager {
         let newState = try await verifyNewAccount(verificationCode: verificationCode)
         logger.debug("Verification code handled. Resulting stage: \(newState.stage.rawValue)")
 
-        guard newState.stage == .signup else {
-            logger.error("Verification completed but resulted in unexpected stage: \(newState.stage.rawValue)")
-            throw ParaError.bridgeError("Verification resulted in unexpected state.")
-        }
         return newState
     }
 


### PR DESCRIPTION
## Summary
- `handleVerificationCode` no longer throws "Verification resulted in unexpected state" when the resulting stage is not `.signup`
- Returns the auth state for all stages so apps can inspect `authState.stage` and route to the appropriate UI
- Companion fix to web-sdk PR (ParaCore.verifyNewAccount)

## Context
A user on the 375go iOS app (BIZ-862) was hitting cascading errors because the app showed verification UI for an existing account. Even after the web-sdk fix stops ParaCore from throwing, the Swift SDK's guard clause would still reject non-`.signup` stages. This removes that guard so apps can recover gracefully.

## Test plan
- [x] Verified `handleVerificationCode` still calls `verifyNewAccount` and parses the result correctly
- [ ] E2E: existing user enters verification code → should get auth state with `.login` stage without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)