### PR TITLE
feat: expose Account Abstraction methods (ENG-6250)

### DIFF
--- a/Sources/ParaSwift/Bridge/ParaWebView.swift
+++ b/Sources/ParaSwift/Bridge/ParaWebView.swift
@@ -213,7 +213,7 @@ public class ParaWebView: NSObject, ObservableObject {
             }
 
             let timeoutTask: Task<Void, Never> = Task { [weak self] in
-                let duration = self?.requestTimeout ?? 30.0
+                let duration = self?.requestTimeout ?? 120.0
                 do {
                     try await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
                     self?.logger.warning("Request timed out: method=\(method) requestId=\(requestId)")

--- a/Sources/ParaSwift/Bridge/ParaWebView.swift
+++ b/Sources/ParaSwift/Bridge/ParaWebView.swift
@@ -40,8 +40,8 @@ public class ParaWebView: NSObject, ObservableObject {
     /// - Parameters:
     ///   - environment: The Para environment configuration
     ///   - apiKey: The API key for Para services
-    ///   - requestTimeout: The timeout duration for requests in seconds (default: 30.0)
-    public init(environment: ParaEnvironment, apiKey: String, requestTimeout: TimeInterval = 30.0) {
+    ///   - requestTimeout: The timeout duration for requests in seconds (default: 120.0, accommodates AA UserOp inclusion)
+    public init(environment: ParaEnvironment, apiKey: String, requestTimeout: TimeInterval = 120.0) {
         logger.info("ParaWebView init: \(environment.name), bridge: \(environment.jsBridgeUrl.absoluteString)")
 
         self.environment = environment

--- a/Sources/ParaSwift/Core/ParaManager+SmartAccount.swift
+++ b/Sources/ParaSwift/Core/ParaManager+SmartAccount.swift
@@ -54,6 +54,7 @@ public extension ParaManager {
         walletId: String? = nil
     ) async throws -> SmartAccountInfo {
         try await ensureWebViewReady()
+        try await ensureTransmissionKeysharesLoaded()
 
         let params = CreateSmartAccountParams(
             provider: provider,
@@ -87,6 +88,7 @@ public extension ParaManager {
         provider: String = "ALCHEMY"
     ) async throws -> AATransactionReceipt {
         try await ensureWebViewReady()
+        try await ensureTransmissionKeysharesLoaded()
 
         let params = SendSmartAccountTransactionParams(
             provider: provider,
@@ -116,6 +118,7 @@ public extension ParaManager {
         provider: String = "ALCHEMY"
     ) async throws -> AATransactionReceipt {
         try await ensureWebViewReady()
+        try await ensureTransmissionKeysharesLoaded()
 
         let params = SendSmartAccountBatchTransactionParams(
             provider: provider,
@@ -154,6 +157,12 @@ public extension ParaManager {
 
     private func decodeReceipt(_ result: Any?, method: String) throws -> AATransactionReceipt {
         let dict = try decodeResult(result, expectedType: [String: Any].self, method: method)
+
+        if let pendingTransactionId = dict["pendingTransactionId"] as? String {
+            let reviewUrl = dict["transactionReviewUrl"] as? String
+            if let reviewUrl { transactionReviewHandler?(reviewUrl) }
+            throw ParaError.transactionDenied(pendingTransactionId: pendingTransactionId, transactionReviewUrl: reviewUrl)
+        }
 
         guard let transactionHash = dict["transactionHash"] as? String else {
             throw ParaError.bridgeError("KEY_ERROR<\(method)-transactionHash>: Missing transactionHash in response")

--- a/Sources/ParaSwift/Core/ParaManager+SmartAccount.swift
+++ b/Sources/ParaSwift/Core/ParaManager+SmartAccount.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+// MARK: - Smart Account (Account Abstraction) Operations
+
+// Inline request payloads — local to the AA bridge module so `BridgeArguments.swift`
+// remains focused on auth/wallet creation.
+
+private struct CreateSmartAccountParams: Encodable {
+    let provider: String
+    let apiKey: String
+    let chainId: Int
+    let gasPolicyId: String?
+    let mode: String
+    let walletId: String?
+}
+
+private struct SendSmartAccountTransactionParams: Encodable {
+    let provider: String
+    let smartAccountAddress: String
+    let chainId: Int
+    let to: String
+    let value: String?
+    let data: String?
+}
+
+private struct SendSmartAccountBatchTransactionParams: Encodable {
+    let provider: String
+    let smartAccountAddress: String
+    let chainId: Int
+    let calls: [SmartAccountCall]
+}
+
+public extension ParaManager {
+    /// Creates (or materializes the counterfactual address of) a smart account backed by an
+    /// Account Abstraction provider such as Alchemy.
+    ///
+    /// The returned ``SmartAccountInfo/smartAccountAddress`` is the address that should send
+    /// transactions and hold funds — not the Para EOA.
+    ///
+    /// - Parameters:
+    ///   - provider: AA provider identifier. Defaults to `"ALCHEMY"`.
+    ///   - apiKey: Provider API key (e.g. your Alchemy app key).
+    ///   - chainId: EVM chain ID to deploy the account on (e.g. `11155111` for Sepolia).
+    ///   - gasPolicyId: Optional Alchemy gas manager policy ID used to sponsor gas.
+    ///   - mode: `"4337"` (default) or `"7702"`.
+    ///   - walletId: Optional Para wallet ID to use as the signer. Defaults to the active EVM wallet.
+    /// - Returns: Metadata describing the smart account.
+    func createSmartAccount(
+        provider: String = "ALCHEMY",
+        apiKey: String,
+        chainId: Int,
+        gasPolicyId: String? = nil,
+        mode: String = "4337",
+        walletId: String? = nil
+    ) async throws -> SmartAccountInfo {
+        try await ensureWebViewReady()
+
+        let params = CreateSmartAccountParams(
+            provider: provider,
+            apiKey: apiKey,
+            chainId: chainId,
+            gasPolicyId: gasPolicyId,
+            mode: mode,
+            walletId: walletId
+        )
+
+        let result = try await postMessage(method: "createSmartAccount", payload: params)
+        return try decodeSmartAccountInfo(result, method: "createSmartAccount")
+    }
+
+    /// Sends a single sponsored transaction through the smart account.
+    ///
+    /// - Parameters:
+    ///   - smartAccountAddress: The address returned by ``createSmartAccount(provider:apiKey:chainId:gasPolicyId:mode:walletId:)``.
+    ///   - chainId: EVM chain ID.
+    ///   - to: Destination address.
+    ///   - value: Amount in wei as a decimal string. Omit for zero-value calls.
+    ///   - data: Optional hex-encoded calldata (including `0x` prefix).
+    ///   - provider: AA provider identifier. Defaults to `"ALCHEMY"`.
+    /// - Returns: A receipt once the UserOperation is mined.
+    func sendSmartAccountTransaction(
+        smartAccountAddress: String,
+        chainId: Int,
+        to: String,
+        value: String? = nil,
+        data: String? = nil,
+        provider: String = "ALCHEMY"
+    ) async throws -> AATransactionReceipt {
+        try await ensureWebViewReady()
+
+        let params = SendSmartAccountTransactionParams(
+            provider: provider,
+            smartAccountAddress: smartAccountAddress,
+            chainId: chainId,
+            to: to,
+            value: value,
+            data: data
+        )
+
+        let result = try await postMessage(method: "sendSmartAccountTransaction", payload: params)
+        return try decodeReceipt(result, method: "sendSmartAccountTransaction")
+    }
+
+    /// Sends multiple calls atomically through the smart account as a single UserOperation.
+    ///
+    /// - Parameters:
+    ///   - smartAccountAddress: The address returned by ``createSmartAccount(provider:apiKey:chainId:gasPolicyId:mode:walletId:)``.
+    ///   - chainId: EVM chain ID.
+    ///   - calls: Ordered list of calls to batch.
+    ///   - provider: AA provider identifier. Defaults to `"ALCHEMY"`.
+    /// - Returns: A single receipt for the batched UserOperation.
+    func sendSmartAccountBatchTransaction(
+        smartAccountAddress: String,
+        chainId: Int,
+        calls: [SmartAccountCall],
+        provider: String = "ALCHEMY"
+    ) async throws -> AATransactionReceipt {
+        try await ensureWebViewReady()
+
+        let params = SendSmartAccountBatchTransactionParams(
+            provider: provider,
+            smartAccountAddress: smartAccountAddress,
+            chainId: chainId,
+            calls: calls
+        )
+
+        let result = try await postMessage(method: "sendSmartAccountBatchTransaction", payload: params)
+        return try decodeReceipt(result, method: "sendSmartAccountBatchTransaction")
+    }
+
+    // MARK: - Private decoding helpers
+
+    private func decodeSmartAccountInfo(_ result: Any?, method: String) throws -> SmartAccountInfo {
+        let dict = try decodeResult(result, expectedType: [String: Any].self, method: method)
+
+        guard let smartAccountAddress = dict["smartAccountAddress"] as? String else {
+            throw ParaError.bridgeError("KEY_ERROR<\(method)-smartAccountAddress>: Missing smartAccountAddress in response")
+        }
+
+        let mode = dict["mode"] as? String ?? "4337"
+        let provider = dict["provider"] as? String ?? "ALCHEMY"
+        let chainId = (dict["chainId"] as? Int)
+            ?? ((dict["chainId"] as? NSNumber)?.intValue)
+            ?? (dict["chainId"] as? String).flatMap { Int($0) }
+            ?? 0
+
+        return SmartAccountInfo(
+            smartAccountAddress: smartAccountAddress,
+            mode: mode,
+            provider: provider,
+            chainId: chainId
+        )
+    }
+
+    private func decodeReceipt(_ result: Any?, method: String) throws -> AATransactionReceipt {
+        let dict = try decodeResult(result, expectedType: [String: Any].self, method: method)
+
+        guard let transactionHash = dict["transactionHash"] as? String else {
+            throw ParaError.bridgeError("KEY_ERROR<\(method)-transactionHash>: Missing transactionHash in response")
+        }
+
+        return AATransactionReceipt(
+            transactionHash: transactionHash,
+            blockHash: dict["blockHash"] as? String ?? "",
+            blockNumber: stringifyNumeric(dict["blockNumber"]),
+            from: dict["from"] as? String ?? "",
+            to: dict["to"] as? String,
+            status: dict["status"] as? String ?? "",
+            gasUsed: stringifyNumeric(dict["gasUsed"]),
+            effectiveGasPrice: stringifyNumeric(dict["effectiveGasPrice"])
+        )
+    }
+
+    /// Bridge may return numeric fields as String, Int, or NSNumber depending on marshalling.
+    /// Normalize to String for consistency and to preserve `uint256` precision.
+    private func stringifyNumeric(_ value: Any?) -> String {
+        if let s = value as? String { return s }
+        if let n = value as? NSNumber { return n.stringValue }
+        if let i = value as? Int { return String(i) }
+        return ""
+    }
+}

--- a/Sources/ParaSwift/Core/ParaManager+SmartAccount.swift
+++ b/Sources/ParaSwift/Core/ParaManager+SmartAccount.swift
@@ -12,6 +12,7 @@ private struct CreateSmartAccountParams: Encodable {
     let gasPolicyId: String?
     let mode: String
     let walletId: String?
+    let address: String?
 }
 
 private struct SendSmartAccountTransactionParams: Encodable {
@@ -43,7 +44,9 @@ public extension ParaManager {
     ///   - chainId: EVM chain ID to deploy the account on (e.g. `11155111` for Sepolia).
     ///   - gasPolicyId: Optional Alchemy gas manager policy ID used to sponsor gas.
     ///   - mode: `"4337"` (default) or `"7702"`.
-    ///   - walletId: Optional Para wallet ID to use as the signer. Defaults to the active EVM wallet.
+    ///   - walletId: Optional Para wallet ID to use as the signer.
+    ///   - address: Optional wallet address to use as the signer. Takes precedence over `walletId`
+    ///     when both are supplied. If neither is provided, defaults to the active EVM wallet.
     /// - Returns: Metadata describing the smart account.
     func createSmartAccount(
         provider: String = "ALCHEMY",
@@ -51,7 +54,8 @@ public extension ParaManager {
         chainId: Int,
         gasPolicyId: String? = nil,
         mode: String = "4337",
-        walletId: String? = nil
+        walletId: String? = nil,
+        address: String? = nil
     ) async throws -> SmartAccountInfo {
         try await ensureWebViewReady()
         try await ensureTransmissionKeysharesLoaded()
@@ -62,7 +66,8 @@ public extension ParaManager {
             chainId: chainId,
             gasPolicyId: gasPolicyId,
             mode: mode,
-            walletId: walletId
+            walletId: walletId,
+            address: address
         )
 
         let result = try await postMessage(method: "createSmartAccount", payload: params)
@@ -72,7 +77,7 @@ public extension ParaManager {
     /// Sends a single sponsored transaction through the smart account.
     ///
     /// - Parameters:
-    ///   - smartAccountAddress: The address returned by ``createSmartAccount(provider:apiKey:chainId:gasPolicyId:mode:walletId:)``.
+    ///   - smartAccountAddress: The address returned by ``createSmartAccount(provider:apiKey:chainId:gasPolicyId:mode:walletId:address:)``.
     ///   - chainId: EVM chain ID.
     ///   - to: Destination address.
     ///   - value: Amount in wei as a decimal string. Omit for zero-value calls.
@@ -106,7 +111,7 @@ public extension ParaManager {
     /// Sends multiple calls atomically through the smart account as a single UserOperation.
     ///
     /// - Parameters:
-    ///   - smartAccountAddress: The address returned by ``createSmartAccount(provider:apiKey:chainId:gasPolicyId:mode:walletId:)``.
+    ///   - smartAccountAddress: The address returned by ``createSmartAccount(provider:apiKey:chainId:gasPolicyId:mode:walletId:address:)``.
     ///   - chainId: EVM chain ID.
     ///   - calls: Ordered list of calls to batch.
     ///   - provider: AA provider identifier. Defaults to `"ALCHEMY"`.

--- a/Sources/ParaSwift/Core/ParaManager+SmartAccount.swift
+++ b/Sources/ParaSwift/Core/ParaManager+SmartAccount.swift
@@ -162,21 +162,12 @@ public extension ParaManager {
         return AATransactionReceipt(
             transactionHash: transactionHash,
             blockHash: dict["blockHash"] as? String ?? "",
-            blockNumber: stringifyNumeric(dict["blockNumber"]),
+            blockNumber: dict["blockNumber"] as? String ?? "",
             from: dict["from"] as? String ?? "",
             to: dict["to"] as? String,
             status: dict["status"] as? String ?? "",
-            gasUsed: stringifyNumeric(dict["gasUsed"]),
-            effectiveGasPrice: stringifyNumeric(dict["effectiveGasPrice"])
+            gasUsed: dict["gasUsed"] as? String ?? "",
+            effectiveGasPrice: dict["effectiveGasPrice"] as? String ?? ""
         )
-    }
-
-    /// Bridge may return numeric fields as String, Int, or NSNumber depending on marshalling.
-    /// Normalize to String for consistency and to preserve `uint256` precision.
-    private func stringifyNumeric(_ value: Any?) -> String {
-        if let s = value as? String { return s }
-        if let n = value as? NSNumber { return n.stringValue }
-        if let i = value as? Int { return String(i) }
-        return ""
     }
 }

--- a/Sources/ParaSwift/Models/AATransactionReceipt.swift
+++ b/Sources/ParaSwift/Models/AATransactionReceipt.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Receipt returned after a smart account transaction (or batch) is mined.
+///
+/// Mirrors the subset of viem's `TransactionReceipt` that the AA bridge serializes —
+/// all numeric fields arrive as decimal strings so they can hold `uint256` values
+/// without loss of precision.
+public struct AATransactionReceipt: Codable, Equatable, Sendable {
+    /// Hash of the mined transaction that executed the UserOperation.
+    public let transactionHash: String
+
+    /// Hash of the block containing the transaction.
+    public let blockHash: String
+
+    /// Block number containing the transaction (decimal string).
+    public let blockNumber: String
+
+    /// Address the transaction was sent from. For AA flows this is typically the bundler / EntryPoint.
+    public let from: String
+
+    /// Address the transaction was sent to. May be nil for contract-creation transactions.
+    public let to: String?
+
+    /// Execution status — `"success"` or `"reverted"`.
+    public let status: String
+
+    /// Gas used by the transaction (decimal string).
+    public let gasUsed: String
+
+    /// Effective gas price paid (decimal string, in wei).
+    public let effectiveGasPrice: String
+
+    public init(
+        transactionHash: String,
+        blockHash: String,
+        blockNumber: String,
+        from: String,
+        to: String?,
+        status: String,
+        gasUsed: String,
+        effectiveGasPrice: String
+    ) {
+        self.transactionHash = transactionHash
+        self.blockHash = blockHash
+        self.blockNumber = blockNumber
+        self.from = from
+        self.to = to
+        self.status = status
+        self.gasUsed = gasUsed
+        self.effectiveGasPrice = effectiveGasPrice
+    }
+}
+
+/// A single call inside a smart account batch transaction.
+public struct SmartAccountCall: Encodable, Equatable, Sendable {
+    /// Destination address.
+    public let to: String
+
+    /// Value in wei, as a decimal string. Omit for zero-value calls.
+    public let value: String?
+
+    /// Hex-encoded calldata (including `0x` prefix). Omit for plain transfers.
+    public let data: String?
+
+    public init(to: String, value: String? = nil, data: String? = nil) {
+        self.to = to
+        self.value = value
+        self.data = data
+    }
+}

--- a/Sources/ParaSwift/Models/SmartAccountInfo.swift
+++ b/Sources/ParaSwift/Models/SmartAccountInfo.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Describes a smart (EIP-4337 / EIP-7702) account provisioned for a Para wallet via an
+/// Account Abstraction provider such as Alchemy.
+public struct SmartAccountInfo: Codable, Equatable, Sendable {
+    /// Counterfactual address of the smart account. This is the address that sends
+    /// transactions and holds funds — not the underlying EOA signer.
+    public let smartAccountAddress: String
+
+    /// Operational mode of the account. Currently `"4337"` (UserOperation) or `"7702"`
+    /// (EIP-7702 delegated EOA).
+    public let mode: String
+
+    /// AA provider that created this account, e.g. `"ALCHEMY"`.
+    public let provider: String
+
+    /// EVM chain ID the smart account is deployed on.
+    public let chainId: Int
+
+    public init(smartAccountAddress: String, mode: String, provider: String, chainId: Int) {
+        self.smartAccountAddress = smartAccountAddress
+        self.mode = mode
+        self.provider = provider
+        self.chainId = chainId
+    }
+}


### PR DESCRIPTION
## Summary

Adds three public methods on `ParaManager` that mirror the new AA handlers in bridge-v2 (web-sdk PR #1644):

- `createSmartAccount(provider:apiKey:chainId:gasPolicyId:mode:walletId:) -> SmartAccountInfo`
- `sendSmartAccountTransaction(smartAccountAddress:chainId:to:value:data:provider:) -> AATransactionReceipt`
- `sendSmartAccountBatchTransaction(smartAccountAddress:chainId:calls:provider:) -> AATransactionReceipt`

Each uses inline `Encodable` param structs + `postMessage` + `decodeResult`, following the `ParaManager+Signing.swift` convention.

## Also bumps ParaWebView default timeout 30s → 120s

AA UserOp inclusion on Sepolia routinely exceeds 30s (observed ~75s in verification). The timeout is per-request, so non-AA calls are unaffected in practice — a 30s request still returns in 30s even with a 120s limit. Callers who want a tighter bound can still pass a custom `requestTimeout` to `ParaWebView.init`.

## Test plan

- [x] `swift build` / `xcodebuild -scheme ParaSwift -sdk iphonesimulator build` succeeds.
- [x] End-to-end verified in the sibling example app (see web-sdk PR #1644): gasless tx `0x44fc3499cb00888e278006169e6b89ab807d55d83e8e485ce6df5e75b2d69554` landed on Sepolia (block 10,680,701).
- [ ] `swiftformat --swiftversion 6.1 .` — not available on the test host; new code follows 4-space indent + repo conventions by eye. Reviewer to run.

## Coordination

Needs to ship + tag a release **before** the web-sdk example PR can merge — the Swift example references this SDK via SPM semver from `github.com/getpara/swift-sdk`.

NO DOCS NEEDED
NO EXAMPLES NEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)