### PR TITLE
feat: add Stellar wallet support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,5 +27,9 @@ let package = Package(
                 "PhoneNumberKit",
             ],
         ),
+        .testTarget(
+            name: "ParaSwiftTests",
+            dependencies: ["ParaSwift"],
+        ),
     ],
 )

--- a/Sources/ParaSwift/Auth/AuthInfo.swift
+++ b/Sources/ParaSwift/Auth/AuthInfo.swift
@@ -8,6 +8,8 @@ public enum ExternalWalletType: String, Codable {
     case solana = "SOLANA"
     /// Cosmos wallet
     case cosmos = "COSMOS"
+    /// Stellar wallet
+    case stellar = "STELLAR"
 }
 
 /// Information about an external wallet

--- a/Sources/ParaSwift/Models/Wallet.swift
+++ b/Sources/ParaSwift/Models/Wallet.swift
@@ -15,6 +15,8 @@ public enum WalletType: String {
     case solana = "SOLANA"
     /// Cosmos blockchain wallet
     case cosmos = "COSMOS"
+    /// Stellar blockchain wallet
+    case stellar = "STELLAR"
 }
 
 /// Represents a cryptocurrency wallet in the Para system
@@ -23,7 +25,7 @@ public struct Wallet {
     public let id: String
     /// ID of the user who owns the wallet
     public let userId: String?
-    /// Type of the wallet (EVM, Solana, Cosmos)
+    /// Type of the wallet (EVM, Solana, Cosmos, Stellar)
     public let type: WalletType?
     /// Identifier for pre-generated wallet
     public let pregenIdentifier: String?

--- a/Sources/ParaSwift/Transactions/StellarTransaction.swift
+++ b/Sources/ParaSwift/Transactions/StellarTransaction.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+public enum StellarNetwork {
+    public static let publicPassphrase = "Public Global Stellar Network ; September 2015"
+    public static let testnetPassphrase = "Test SDF Network ; September 2015"
+}
+
+public struct StellarAsset: Encodable {
+    public let code: String
+    public let issuer: String
+
+    public init(code: String, issuer: String) {
+        self.code = code
+        self.issuer = issuer
+    }
+}
+
+public struct StellarMemo: Encodable {
+    public let type: String
+    public let value: String
+
+    public static func text(_ value: String) -> StellarMemo {
+        StellarMemo(type: "text", value: value)
+    }
+
+    public static func id(_ value: String) -> StellarMemo {
+        StellarMemo(type: "id", value: value)
+    }
+
+    public static func hash(_ value: String) -> StellarMemo {
+        StellarMemo(type: "hash", value: value)
+    }
+
+    public static func returnHash(_ value: String) -> StellarMemo {
+        StellarMemo(type: "return", value: value)
+    }
+}
+
+public struct StellarTransaction: Encodable {
+    public let to: String?
+    public let amount: String?
+    public let asset: StellarAsset?
+    public let memo: StellarMemo?
+    public let networkPassphrase: String?
+    public let fee: String?
+    public let timeout: Int?
+    public let sequenceNumber: String?
+    public let serializedXDR: String?
+
+    public init(
+        to: String,
+        amount: String,
+        asset: StellarAsset? = nil,
+        memo: StellarMemo? = nil,
+        networkPassphrase: String? = nil,
+        fee: String? = nil,
+        timeout: Int? = nil,
+        sequenceNumber: String? = nil
+    ) {
+        self.to = to
+        self.amount = amount
+        self.asset = asset
+        self.memo = memo
+        self.networkPassphrase = networkPassphrase
+        self.fee = fee
+        self.timeout = timeout
+        self.sequenceNumber = sequenceNumber
+        serializedXDR = nil
+    }
+
+    public init(serializedXDR: String, networkPassphrase: String? = nil) {
+        to = nil
+        amount = nil
+        asset = nil
+        memo = nil
+        self.networkPassphrase = networkPassphrase
+        fee = nil
+        timeout = nil
+        sequenceNumber = nil
+        self.serializedXDR = serializedXDR
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode("STELLAR", forKey: .chainType)
+        try container.encodeIfPresent(to, forKey: .to)
+        try container.encodeIfPresent(amount, forKey: .amount)
+        try container.encodeIfPresent(asset, forKey: .asset)
+        try container.encodeIfPresent(memo, forKey: .memo)
+        try container.encodeIfPresent(networkPassphrase, forKey: .networkPassphrase)
+        try container.encodeIfPresent(fee, forKey: .fee)
+        try container.encodeIfPresent(timeout, forKey: .timeout)
+        try container.encodeIfPresent(sequenceNumber, forKey: .sequenceNumber)
+
+        if let serializedXDR {
+            try container.encode("serialized", forKey: .type)
+            try container.encode(serializedXDR, forKey: .data)
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case chainType, to, amount, asset, memo, networkPassphrase, fee, timeout, sequenceNumber, type, data
+    }
+}

--- a/Sources/ParaSwift/Utils/StellarAddress.swift
+++ b/Sources/ParaSwift/Utils/StellarAddress.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+public enum StellarAddressError: Error, LocalizedError {
+    case invalidHexPublicKey
+    case invalidBase58Character(Character)
+    case invalidPublicKeyLength(Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidHexPublicKey:
+            "Invalid hex public key"
+        case let .invalidBase58Character(character):
+            "Invalid base58 character: \(character)"
+        case let .invalidPublicKeyLength(length):
+            "Invalid Ed25519 public key length: expected 32 bytes, got \(length)"
+        }
+    }
+}
+
+public enum StellarAddress {
+    private static let base32Alphabet = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567")
+    private static let base58Alphabet = Array("123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz")
+    private static let versionByte = UInt8(6 << 3)
+
+    public static func fromPublicKey(_ publicKey: String) throws -> String {
+        guard !publicKey.isEmpty else { return "" }
+        return try encodeEd25519PublicKey(hexDecode(publicKey))
+    }
+
+    public static func fromSolanaAddress(_ solanaAddress: String) throws -> String {
+        guard !solanaAddress.isEmpty else { return "" }
+        return try encodeEd25519PublicKey(base58Decode(solanaAddress))
+    }
+
+    private static func hexDecode(_ value: String) throws -> [UInt8] {
+        let normalized = value.hasPrefix("0x") || value.hasPrefix("0X") ? String(value.dropFirst(2)) : value
+        guard !normalized.isEmpty, normalized.count.isMultiple(of: 2) else {
+            throw StellarAddressError.invalidHexPublicKey
+        }
+
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(normalized.count / 2)
+        var index = normalized.startIndex
+
+        while index < normalized.endIndex {
+            let nextIndex = normalized.index(index, offsetBy: 2)
+            guard let byte = UInt8(normalized[index ..< nextIndex], radix: 16) else {
+                throw StellarAddressError.invalidHexPublicKey
+            }
+            bytes.append(byte)
+            index = nextIndex
+        }
+
+        return bytes
+    }
+
+    private static func base58Decode(_ value: String) throws -> [UInt8] {
+        var bytes = [UInt8(0)]
+
+        for character in value {
+            guard let digit = base58Alphabet.firstIndex(of: character) else {
+                throw StellarAddressError.invalidBase58Character(character)
+            }
+
+            var carry = digit
+            for index in bytes.indices {
+                carry += Int(bytes[index]) * 58
+                bytes[index] = UInt8(carry & 0xff)
+                carry >>= 8
+            }
+
+            while carry > 0 {
+                bytes.append(UInt8(carry & 0xff))
+                carry >>= 8
+            }
+        }
+
+        let leadingZeros = value.prefix { $0 == "1" }.count
+        var significantBytes = bytes.count
+        while significantBytes > 0, bytes[significantBytes - 1] == 0 {
+            significantBytes -= 1
+        }
+
+        var result = Array(repeating: UInt8(0), count: leadingZeros + significantBytes)
+        for index in 0 ..< significantBytes {
+            result[leadingZeros + significantBytes - 1 - index] = bytes[index]
+        }
+        return result
+    }
+
+    private static func encodeEd25519PublicKey(_ publicKeyBytes: [UInt8]) throws -> String {
+        guard publicKeyBytes.count == 32 else {
+            throw StellarAddressError.invalidPublicKeyLength(publicKeyBytes.count)
+        }
+
+        let payload = [versionByte] + publicKeyBytes
+        let checksum = crc16XModem(payload)
+        let full = payload + [UInt8(checksum & 0xff), UInt8((checksum >> 8) & 0xff)]
+        return base32Encode(full)
+    }
+
+    private static func crc16XModem(_ bytes: [UInt8]) -> UInt16 {
+        var crc = UInt32(0)
+        for byte in bytes {
+            crc ^= UInt32(byte) << 8
+            for _ in 0 ..< 8 {
+                crc = (crc & 0x8000) != 0 ? (crc << 1) ^ 0x1021 : crc << 1
+                crc &= 0xffff
+            }
+        }
+        return UInt16(crc)
+    }
+
+    private static func base32Encode(_ bytes: [UInt8]) -> String {
+        var result = ""
+        var bits = 0
+        var value = 0
+
+        for byte in bytes {
+            value = (value << 8) | Int(byte)
+            bits += 8
+            while bits >= 5 {
+                result.append(base32Alphabet[(value >> (bits - 5)) & 0x1f])
+                bits -= 5
+            }
+        }
+
+        if bits > 0 {
+            result.append(base32Alphabet[(value << (5 - bits)) & 0x1f])
+        }
+        return result
+    }
+}
+
+public extension Wallet {
+    var stellarAddress: String? {
+        if let publicKey {
+            return try? StellarAddress.fromPublicKey(publicKey)
+        }
+        if let address {
+            return try? StellarAddress.fromSolanaAddress(address)
+        }
+        return nil
+    }
+}

--- a/Tests/ParaSwiftTests/StellarTests.swift
+++ b/Tests/ParaSwiftTests/StellarTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import ParaSwift
+
+final class StellarTests: XCTestCase {
+    func testWalletTypeDecodesStellar() {
+        let wallet = Wallet(result: [
+            "id": "stellar-wallet",
+            "type": "STELLAR",
+            "address": "GDNE6FB6Z4PD4DLHQDAJMXFZKCXOJGHFDKRJV4FM7QXCHY2ZUPRDEZKV",
+            "scheme": "ED25519",
+        ])
+
+        XCTAssertEqual(wallet.type, .stellar)
+        XCTAssertEqual(wallet.address, "GDNE6FB6Z4PD4DLHQDAJMXFZKCXOJGHFDKRJV4FM7QXCHY2ZUPRDEZKV")
+    }
+
+    func testStellarTransactionPaymentEncodesBridgePayload() throws {
+        let transaction = StellarTransaction(
+            to: "GDESTINATION1234567890",
+            amount: "10.5",
+            memo: .text("hello"),
+            networkPassphrase: StellarNetwork.testnetPassphrase,
+            fee: "100",
+            timeout: 60,
+            sequenceNumber: "12345"
+        )
+
+        let payload = try encodedPayload(transaction)
+
+        XCTAssertEqual(payload["chainType"] as? String, "STELLAR")
+        XCTAssertEqual(payload["to"] as? String, "GDESTINATION1234567890")
+        XCTAssertEqual(payload["amount"] as? String, "10.5")
+        XCTAssertEqual(payload["networkPassphrase"] as? String, StellarNetwork.testnetPassphrase)
+        XCTAssertEqual(payload["fee"] as? String, "100")
+        XCTAssertEqual(payload["timeout"] as? Int, 60)
+        XCTAssertEqual(payload["sequenceNumber"] as? String, "12345")
+
+        let memo = try XCTUnwrap(payload["memo"] as? [String: Any])
+        XCTAssertEqual(memo["type"] as? String, "text")
+        XCTAssertEqual(memo["value"] as? String, "hello")
+    }
+
+    func testStellarTransactionSerializedXDREncodesBridgePayload() throws {
+        let transaction = StellarTransaction(
+            serializedXDR: "AAAAAgAAA...",
+            networkPassphrase: StellarNetwork.publicPassphrase
+        )
+
+        let payload = try encodedPayload(transaction)
+
+        XCTAssertEqual(payload["chainType"] as? String, "STELLAR")
+        XCTAssertEqual(payload["type"] as? String, "serialized")
+        XCTAssertEqual(payload["data"] as? String, "AAAAAgAAA...")
+        XCTAssertEqual(payload["networkPassphrase"] as? String, StellarNetwork.publicPassphrase)
+    }
+
+    func testDerivesStellarAddressFromHexPublicKey() throws {
+        let publicKeyHex = "da4f143ecf1e3e0d6780c0965cb950aee498e51aa29af0acfc2e23e359a3e232"
+
+        let address = try StellarAddress.fromPublicKey(publicKeyHex)
+
+        XCTAssertEqual(address, "GDNE6FB6Z4PD4DLHQDAJMXFZKCXOJGHFDKRJV4FM7QXCHY2ZUPRDEZKV")
+    }
+
+    func testDerivesStellarAddressFromSolanaAddress() throws {
+        let solanaAddress = "FhBpLCxutevuuZ8bnQMLSvQ6Z9tLXr6vZP5DLSbbDpGq"
+
+        let address = try StellarAddress.fromSolanaAddress(solanaAddress)
+
+        XCTAssertEqual(address, "GDNE6FB6Z4PD4DLHQDAJMXFZKCXOJGHFDKRJV4FM7QXCHY2ZUPRDEZKV")
+    }
+
+    private func encodedPayload<T: Encodable>(_ value: T) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(value)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+}


### PR DESCRIPTION
## Problem

Para Swift SDK did not expose Stellar as a wallet type or provide the small Stellar payload/address helpers needed for apps to create, display, and sign with Stellar wallets through the existing bridge.

## Solution

- Add `STELLAR` wallet/external-wallet type support.
- Add Stellar G-address derivation from Ed25519 public keys and Solana-style base58 addresses.
- Add minimal Stellar transaction/memo/network models that encode into the existing bridge signing path.
- Add focused XCTest coverage for wallet decoding, transaction payload encoding, and address derivation vectors.

## Verification

- `xcodebuild -workspace /Users/tyson/para/ParaSwift.xcworkspace -scheme ParaSwift -sdk iphonesimulator -configuration Release build`
- `xcodebuild -workspace /Users/tyson/para/ParaSwift.xcworkspace -scheme ParaSwift -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 17,OS=26.5" test`
- `swift test` is not viable for this package on macOS because the SDK imports UIKit.
- `swiftformat .` was not run because `swiftformat` is not installed locally.

## Companion PRs

- Swift example: https://github.com/capsule-org/js-monorepo/pull/1778
- Flutter SDK: https://github.com/capsule-org/flutter-sdk/pull/81
- Flutter example: https://github.com/capsule-org/js-monorepo/pull/1772

## Notes

Core JS Stellar support already exists from js-monorepo PR #1545 / commit 648f5bb55.